### PR TITLE
Cassandra: Create keyspace in initializeSchema

### DIFF
--- a/src/main/resources/application.json
+++ b/src/main/resources/application.json
@@ -3,8 +3,7 @@
         "netscout": {
             "aion2": {
                 "cassandra": {
-                    "contactPoints": ["127.0.0.1"],
-                    "keyspace": "aion"
+                    "contactPoints": ["127.0.0.1"]
                 }
             }
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+com.netscout.aion2.cassandra.keyspace.name=aion
+com.netscout.aion2.cassandra.keyspace.replication.clazz=SimpleStrategy
+com.netscout.aion2.cassandra.keyspace.replication.replicationFactor=1

--- a/src/test/resources/com/netscout/aion2/complete.json
+++ b/src/test/resources/com/netscout/aion2/complete.json
@@ -3,7 +3,13 @@
         "netscout": {
             "aion2": {
                 "cassandra": {
-                    "keyspace": "aion",
+                    "keyspace": {
+                        "name": "aion",
+                        "replication": {
+                            "clazz": "SimpleStrategy",
+                            "replicationFactor": 1
+                        }
+                    },
                     "contactPoints": ["127.0.0.1"]
                 }
             }

--- a/src/test/resources/com/netscout/aion2/defaults.json
+++ b/src/test/resources/com/netscout/aion2/defaults.json
@@ -3,7 +3,13 @@
         "netscout": {
             "aion2": {
                 "cassandra": {
-                    "keyspace": "aion",
+                    "keyspace": {
+                        "name": "aion",
+                        "replication": {
+                            "clazz": "SimpleStrategy",
+                            "replicationFactor": 1
+                        }
+                    },
                     "contactPoints": ["127.0.0.1"]
                 }
             }

--- a/src/test/scala/com/netscout/aion2/source/CassandraDataSourceSpec.scala
+++ b/src/test/scala/com/netscout/aion2/source/CassandraDataSourceSpec.scala
@@ -58,8 +58,15 @@ class CassandraDataSourceSpec extends FlatSpec with Matchers with MockitoSugar {
     val f = defaultFixture
     f.uut.initializeSchema(schemaProvider.schema)
 
-    // Because there's 3 indices 
-    verify(f.testModule.session, times(3)).execute(anyString())
+    // Because there's 3 indices and one keyspace
+    verify(f.testModule.session, times(4)).execute(anyString())
+  }
+
+  it should "create correct keyspace in initializeSchema" in {
+    val f = defaultFixture
+    f.uut.initializeSchema(Set())
+
+    verify(f.testModule.session).execute("CREATE KEYSPACE IF NOT EXISTS aion WITH REPLICATION = {\'class\': \'SimpleStrategy\', \'replication_factor\': 1}")
   }
 
   it should "create correct table for single partition key index" in {


### PR DESCRIPTION
CassandraDataSource now loads more complete keyspace configuration
from typesafe config.

Fix #55 