### PR TITLE
cassandra: Support CQL collections types

### DIFF
--- a/src/main/resources/com/netscout/aion2/schema.yml
+++ b/src/main/resources/com/netscout/aion2/schema.yml
@@ -1,5 +1,27 @@
 ---
 objects:
+  - name: playdough_test_results
+    fields:
+      time: timestamp
+      org: uuid
+      pulse: uuid
+      test: uuid
+      metrics: map<text,double>
+    indices:
+      - name: org_pulse_test
+        partition:
+          - org
+          - pulse
+          - test
+        split:
+          column: time
+          strategy:
+            name: duration
+            config:
+              duration: P30D
+        clustering:
+          field: time
+          order: DESC
   - name: redstone_defect_stats
     fields:
       time: timeuuid

--- a/src/test/resources/com/netscout/aion2/schema-complete.yml
+++ b/src/test/resources/com/netscout/aion2/schema-complete.yml
@@ -6,6 +6,7 @@ objects:
       range: text
       time: timeuuid
       data: blob
+      datam: map<text,blob>
     indices:
       - name: single_partition
         partition:

--- a/src/test/scala/com/netscout/aion2/ApplicationSpec.scala
+++ b/src/test/scala/com/netscout/aion2/ApplicationSpec.scala
@@ -164,7 +164,8 @@ class ApplicationSpec extends FlatSpec with Matchers with MockitoSugar {
         "partition" -> "text",
         "range" -> "text",
         "time" -> "timeuuid",
-        "data" -> "blob"
+        "data" -> "blob",
+        "datam" -> "map<text,blob>"
       )
     )
   }

--- a/src/test/scala/com/netscout/aion2/source/CassandraDataSourceSpec.scala
+++ b/src/test/scala/com/netscout/aion2/source/CassandraDataSourceSpec.scala
@@ -96,7 +96,7 @@ class CassandraDataSourceSpec extends FlatSpec with Matchers with MockitoSugar {
     verify(f.testModule.session).execute("CREATE TABLE IF NOT EXISTS aion.foo_no_partition (time_row timestamp, partition text, range text, time timeuuid, data blob, PRIMARY KEY ((time_row), time))")
   }
 
-  it should "map classes for cassandra types" in {
+  it should "map classes for cassandra primitive types" in {
     val f = defaultFixture
 
     val typesToTest = Seq(
@@ -117,6 +117,27 @@ class CassandraDataSourceSpec extends FlatSpec with Matchers with MockitoSugar {
     for (t <- typesToTest) {
       f.uut.classOfType(t) should not be (null)
     }
+  }
+
+  it should "map classes for cassandra map type" in {
+    val f = defaultFixture
+
+    val c = f.uut.classOfType("map<text,text>")
+    c should equal (classOf[java.util.Map[String, String]])
+  }
+
+  it should "map classes for cassandra set type" in {
+    val f = defaultFixture
+
+    val c = f.uut.classOfType("set<text>")
+    c should equal (classOf[java.util.Set[String]])
+  }
+
+  it should "map classes for cassandra list type" in {
+    val f = defaultFixture
+
+    val c = f.uut.classOfType("list<text>")
+    c shouldEqual classOf[java.util.List[String]]
   }
 
   it should "throw IllegalTypeException for an unrecognized type" in {

--- a/src/test/scala/com/netscout/aion2/source/CassandraDataSourceSpec.scala
+++ b/src/test/scala/com/netscout/aion2/source/CassandraDataSourceSpec.scala
@@ -75,7 +75,7 @@ class CassandraDataSourceSpec extends FlatSpec with Matchers with MockitoSugar {
     val f = defaultFixture
     f.uut.initializeSchema(schemaProvider.schema)
 
-    verify(f.testModule.session).execute("CREATE TABLE IF NOT EXISTS aion.foo_single_partition (time_row timestamp, partition text, range text, time timeuuid, data blob, PRIMARY KEY ((time_row, partition), time))")
+    verify(f.testModule.session).execute("CREATE TABLE IF NOT EXISTS aion.foo_single_partition (time_row timestamp, partition text, range text, time timeuuid, data blob, datam map<text,blob>, PRIMARY KEY ((time_row, partition), time))")
   }
 
   it should "create correct table for double partition key index" in {
@@ -84,7 +84,7 @@ class CassandraDataSourceSpec extends FlatSpec with Matchers with MockitoSugar {
     val f = defaultFixture
     f.uut.initializeSchema(schemaProvider.schema)
 
-    verify(f.testModule.session).execute("CREATE TABLE IF NOT EXISTS aion.foo_double_partition (time_row timestamp, partition text, range text, time timeuuid, data blob, PRIMARY KEY ((time_row, partition, range), time))")
+    verify(f.testModule.session).execute("CREATE TABLE IF NOT EXISTS aion.foo_double_partition (time_row timestamp, partition text, range text, time timeuuid, data blob, datam map<text,blob>, PRIMARY KEY ((time_row, partition, range), time))")
   }
 
   it should "create correct table for no partition key index" in {
@@ -93,7 +93,7 @@ class CassandraDataSourceSpec extends FlatSpec with Matchers with MockitoSugar {
     val f = defaultFixture
     f.uut.initializeSchema(schemaProvider.schema)
 
-    verify(f.testModule.session).execute("CREATE TABLE IF NOT EXISTS aion.foo_no_partition (time_row timestamp, partition text, range text, time timeuuid, data blob, PRIMARY KEY ((time_row), time))")
+    verify(f.testModule.session).execute("CREATE TABLE IF NOT EXISTS aion.foo_no_partition (time_row timestamp, partition text, range text, time timeuuid, data blob, datam map<text,blob>, PRIMARY KEY ((time_row), time))")
   }
 
   it should "map classes for cassandra primitive types" in {
@@ -180,10 +180,10 @@ class CassandraDataSourceSpec extends FlatSpec with Matchers with MockitoSugar {
     val response = f.uut.executeQuery(obj, index, queryStrategy, Map("partition" -> "somePartition"))
 
     verify(f.testModule.session).execute(argThat(new ArgumentMatcher[Statement] {
-      override def matches(obj: Object) = obj.toString equals s"SELECT range,system.dateof(time),data FROM aion.foo_single_partition WHERE partition='somePartition' AND time>=minTimeuuid(${Instant.EPOCH.plus(1, HOURS).toEpochMilli}) AND time<maxTimeuuid(${Instant.EPOCH.plus(2, HOURS).toEpochMilli}) AND time_row=${Instant.EPOCH.toEpochMilli};"
+      override def matches(obj: Object) = obj.toString equals s"SELECT range,system.dateof(time),data,datam FROM aion.foo_single_partition WHERE partition='somePartition' AND time>=minTimeuuid(${Instant.EPOCH.plus(1, HOURS).toEpochMilli}) AND time<maxTimeuuid(${Instant.EPOCH.plus(2, HOURS).toEpochMilli}) AND time_row=${Instant.EPOCH.toEpochMilli};"
     }))
     verify(f.testModule.session).execute(argThat(new ArgumentMatcher[Statement] {
-      override def matches(obj: Object) = obj.toString equals s"SELECT range,system.dateof(time),data FROM aion.foo_single_partition WHERE time_row=${Instant.EPOCH.plus(1, DAYS).toEpochMilli} AND partition='somePartition';"
+      override def matches(obj: Object) = obj.toString equals s"SELECT range,system.dateof(time),data,datam FROM aion.foo_single_partition WHERE time_row=${Instant.EPOCH.plus(1, DAYS).toEpochMilli} AND partition='somePartition';"
     }))
   }
 


### PR DESCRIPTION
This adds support for CQL3 collections types:

* `map`
* `list`
* `set`

Close #65 